### PR TITLE
Serialize Pulumi publish steps to avoid Inferno.Common build races

### DIFF
--- a/Inferno.Deploy/Program.cs
+++ b/Inferno.Deploy/Program.cs
@@ -128,18 +128,29 @@ return await Deployment.RunAsync(() =>
     // Resolve ~ to absolute path (CopyToRemote and systemd don't expand ~)
     var absoluteRemotePath = remotePath.Replace("~", $"/home/{piUser}");
 
-    // Step 1: Publish each project independently, triggered by its own source hash
+    // Step 1: Publish each project, triggered by its own source hash. Chain them so
+    // they run one at a time: every service references Inferno.Common, so parallel
+    // `dotnet publish` runs would rebuild Common concurrently and collide on its
+    // obj/bin outputs (MSBuild file locks). DependsOn on the previous publish
+    // serializes them and removes the contention.
     var publishOps = new Dictionary<string, LocalCommand>();
     var sourceHashes = new Dictionary<string, string>();
+    LocalCommand? previousPublish = null;
     foreach (var svc in services)
     {
         var hash = SourceHash.Compute("..", serviceDeps[svc]);
         sourceHashes[svc] = hash;
+        var publishOpts = new CustomResourceOptions();
+        if (previousPublish != null)
+        {
+            publishOpts.DependsOn.Add(previousPublish);
+        }
         publishOps[svc] = new LocalCommand($"publish-{svc}", new Pulumi.Command.Local.CommandArgs
         {
             Create = $"dotnet publish ../{projectMap[svc]} -c Release -o ../publish/{svc}",
             Triggers = new[] { hash },
-        });
+        }, publishOpts);
+        previousPublish = publishOps[svc];
     }
 
     // Step 2: Copy published artifacts to the Pi (Pulumi diffs the file archive)


### PR DESCRIPTION
## What & why

Fixes the Pulumi deploy failure during the publish step.

`Inferno.Deploy/Program.cs` created three `LocalCommand`s — `publish-api`, `publish-mqtt`, `publish-cli` — with **no dependency between them**, so Pulumi ran the three `dotnet publish` commands **in parallel**. Every service references `Inferno.Common` (see `serviceDeps`), so the parallel publishes rebuilt `Inferno.Common` concurrently and collided on its `obj/`+`bin/` outputs (MSBuild file locks), failing the deploy.

## Change

Chain each publish command to the previous one via `DependsOn`, serializing them (`publish-api → publish-mqtt → publish-cli`) so only one `dotnet publish` touches the shared `Inferno.Common` build outputs at a time. Ordering only — no functional change, and downstream `copy`/`restart` dependencies are untouched.

## Notes
- This is a latent deploy bug, **not** caused by the stability work in #20 — the merge (plus a Pulumi trigger set to fire on every commit rather than on `v*` tags) just surfaced it. Worth re-checking that the Pulumi Cloud trigger is back on tags so untagged commits don't auto-deploy.

## Verification
- `dotnet build Inferno.Deploy/Inferno.Deploy.csproj` → clean (0 warnings).
- Real validation is the next `pulumi up` / `pulumi preview` completing the publish step without the file-lock error.

https://claude.ai/code/session_01T8v7xa23G8v1GjsSFBwzme

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8v7xa23G8v1GjsSFBwzme)_