### PR TITLE
Make Sear full-feed gate relative to ignition temp

### DIFF
--- a/Inferno.Api/Services/FireMinder.cs
+++ b/Inferno.Api/Services/FireMinder.cs
@@ -37,10 +37,25 @@ namespace Inferno.Api.Services
         double _ignitionHigh;
         bool _fireStarted;
         int _ignitionTemp;
+        /// <summary>
+        /// Grill temperature at which the fire was first declared started, captured
+        /// once on the initial ignition. Unlike <see cref="_ignitionTemp"/> — which the
+        /// recovery path raises to the fire-check temp when relighting a struggling
+        /// fire — this stays anchored to where the fire actually caught. That lets Sear
+        /// gate its full-feed transition on a margin above the catch temp instead of a
+        /// fixed absolute temperature that a cold or windy firepot may never reach.
+        /// </summary>
+        int _initialIgnitionTemp;
         bool _initialIgnition;
 
         public bool IsFireHealthy => !_fireCheck;
         public bool IsFireStarted => _fireStarted;
+        /// <summary>
+        /// Grill temp (F) at which the fire was first declared started. Anchored to the
+        /// initial catch — never raised by recovery relights — so callers can derive a
+        /// relative establish threshold from it.
+        /// </summary>
+        public int InitialIgnitionTemp => _initialIgnitionTemp;
         public bool IsReigniting => _fireCheck && _igniter.IsOn;
         // Recovery dominates: never report a lid-open while we're actively recovering,
         // so the Smoker stays on the aggressive RecoveryFeed instead of the floor.
@@ -63,6 +78,9 @@ namespace Inferno.Api.Services
             _fireCheck = false;
             _initialIgnition = true;
             _ignitionTemp = 150;
+            // Conservative default so Sear's relative establish gate stays high until
+            // the fire actually catches (and overwrites this with the real catch temp).
+            _initialIgnitionTemp = 150;
             _belowCheckSince = null;
             _recoveryHigh = 0;
             _ignitionHigh = 0;
@@ -177,6 +195,12 @@ namespace Inferno.Api.Services
                 if(_smoker.Temps.GrillTemp >= _ignitionTemp)
                 {
                     // The fire has started, make sure the igniter is off
+                    if (!_fireStarted)
+                    {
+                        // Capture where the fire caught, once. Recovery may later raise
+                        // _ignitionTemp, but this anchor must stay at the initial catch.
+                        _initialIgnitionTemp = _ignitionTemp;
+                    }
                     _fireStarted = true;
                     _igniter.Off();
                 }

--- a/Inferno.Api/Services/Smoker.cs
+++ b/Inferno.Api/Services/Smoker.cs
@@ -28,6 +28,16 @@ namespace Inferno.Api.Services
         int _maxGrillTemp = 425;
 
         /// <summary>
+        /// In Sear, how far above the ignition temperature the grill must climb before
+        /// the auger switches from the gentle establishing feed to a continuous full
+        /// feed. A margin relative to where the fire actually caught — not a fixed
+        /// absolute temp — so a cold or windy start (where the firepot settles lower)
+        /// still reaches full feed instead of stalling under the old absolute 180F gate.
+        /// Lower this if the worst windy days still stall before full feed.
+        /// </summary>
+        int _searEstablishMargin = 25;
+
+        /// <summary>
         /// Timeout for the blower to run after shutdown.
         /// </summary>
         TimeSpan _shutdownBlowerTimeout = TimeSpan.FromMinutes(10);
@@ -489,9 +499,10 @@ namespace Inferno.Api.Services
                return;
             }
 
-            if (_rtdArray.GrillTemp < _minSetPoint)
+            int establishTemp = _fireMinder.InitialIgnitionTemp + _searEstablishMargin;
+            if (_rtdArray.GrillTemp < establishTemp)
             {
-                Debug.WriteLine($"Sear: Grill temp {_rtdArray.GrillTemp} below {_minSetPoint}. Diverting to SMOKE to establish fire.");
+                Debug.WriteLine($"Sear: Grill temp {_rtdArray.GrillTemp} below establish temp {establishTemp} (ignition {_fireMinder.InitialIgnitionTemp} + {_searEstablishMargin}). Diverting to SMOKE to establish fire.");
                 await Smoke();
                 return;
             }

--- a/Inferno.Tests/FireMinderTests.cs
+++ b/Inferno.Tests/FireMinderTests.cs
@@ -183,6 +183,60 @@ public class FireMinderTests
     }
 
     [Fact]
+    public void InitialIgnitionTemp_DefaultsToFloor_BeforeFireStarts()
+    {
+        var smoker = new FakeSmoker { Mode = SmokerMode.Sear, SetPoint = 400 };
+        var igniter = new FakeRelay();
+        var fm = new FireMinder(smoker, igniter, autoStart: false);
+        fm.ResetFireStatus();
+
+        // Before the fire catches, the anchor sits at the 150F floor so Sear's
+        // relative establish gate stays conservative.
+        Assert.False(fm.IsFireStarted);
+        Assert.Equal(150, fm.InitialIgnitionTemp);
+    }
+
+    [Fact]
+    public void ColdStart_CapturesInitialIgnitionTempAtCatch()
+    {
+        var smoker = new FakeSmoker { Mode = SmokerMode.Sear, SetPoint = 400 };
+        var igniter = new FakeRelay();
+        var clock = new TestClock();
+        var fm = new FireMinder(smoker, igniter, () => clock.Now, autoStart: false);
+        fm.ResetFireStatus();
+
+        SetGrill(smoker, 75);
+        fm.Tick();                       // igniter lights; ignition temp floors at 150
+        Assert.True(igniter.IsOn);
+        Assert.False(fm.IsFireStarted);
+
+        SetGrill(smoker, 152);
+        fm.Tick();                       // crosses 150 → fire started
+
+        Assert.True(fm.IsFireStarted);
+        Assert.Equal(150, fm.InitialIgnitionTemp);
+    }
+
+    [Fact]
+    public void InitialIgnitionTemp_UnchangedByRecoveryRelight()
+    {
+        // EstablishedFire catches cold (grill jumps to 200 over the 150 floor).
+        var (fm, smoker, igniter, clock) = EstablishedFire();
+        Assert.Equal(150, fm.InitialIgnitionTemp);
+
+        // Trip recovery: the relight raises the internal ignition threshold to the
+        // fire-check temp (195), but the initial-catch anchor must stay put so Sear's
+        // establish gate doesn't drift upward after a recovery.
+        SetGrill(smoker, 180);
+        fm.Tick();
+        clock.Advance(TimeSpan.FromSeconds(46));
+        fm.Tick();
+        Assert.True(fm.IsReigniting);
+
+        Assert.Equal(150, fm.InitialIgnitionTemp);
+    }
+
+    [Fact]
     public void BriefDip_RecoversBeforeDebounce_DoesNotTrip()
     {
         var (fm, smoker, igniter, clock) = EstablishedFire();


### PR DESCRIPTION
## Problem

In **Sear** mode the auger only switched from the gentle establishing feed to a continuous full feed once the grill crossed an absolute **180°F** (`_minSetPoint`).

But `FireMinder` declares the fire "started" and **turns the igniter off at ~150°F**. So from 150→180°F the fire has to climb 30°F on the slow Smoke-style trickle with *no* igniter assist. On a cold or windy day the firepot settles lower than that — the grill stalls in the 150–180°F band and never reaches full feed. (That band is also unmonitored by the recovery watchdog, which in Sear only arms above ~340°F, so a fire that dies there isn't relit.)

## Fix

Replace the absolute gate with a margin *relative to where the fire actually caught*:

- `FireMinder` now exposes **`InitialIgnitionTemp`** — the grill temp at the first ignition, captured once and **never raised by recovery relights** (the existing `_ignitionTemp` gets bumped to the fire-check temp during a recovery, so it can't be used directly without re-introducing a stall band after recovery).
- `Smoker.Sear()` gates full feed at `InitialIgnitionTemp + _searEstablishMargin` (**default 25°F, tunable**) instead of the fixed 180°F.

This keeps a sensible "establish" margin above the catch temp while scaling with conditions, so cold/windy starts reach full feed instead of stalling. The 150°F lit-detection itself is unchanged (acts as a safety floor for the anchor).

`_searEstablishMargin` is the single knob to turn down if the worst windy days still stall before full feed.

## Tests

Added `FireMinder` tests covering:
- the default 150°F floor before the fire catches,
- cold-start capture of the catch temp, and
- that a recovery relight does **not** move the anchor.

All 71 tests pass; clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APzBbDz9nDWgpiCi1A48vw

---
_Generated by [Claude Code](https://claude.ai/code/session_01APzBbDz9nDWgpiCi1A48vw)_